### PR TITLE
892102: Handled the PDF export on docker linux environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+RUN apt-get update -y && apt-get install fontconfig -y
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443

--- a/src/ej2-spreadsheet-server/ej2-spreadsheet-server.csproj
+++ b/src/ej2-spreadsheet-server/ej2-spreadsheet-server.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Syncfusion.EJ2.Spreadsheet.AspNet.Core" Version="*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- The docker runs in the Linus environment, in that the XLSIO loaded SkiaSharp package is not compatible, which is the root cause for the issue.
- Added SkiaSharp Linux package which is required for the save as PDF action.
- Still, the exception occurs because it requires font config which will not load by default in the Linux environment.
- Installed the font using the docker file which is used for the SkiaSharp package processing during Excel to PDF conversion.
- Now the save as PDF works properly.
- Ensured saving PDFs with different sets of contents.
- Found that the regional languages are not updated while saving as PDF on search regarding this case. some of the language fonts are not supported by default. the customer has to add it to the container using the docker commands once the docker is pulled and the container is generated.
- I have ensured this case by adding all the fonts from my machine into the docker container and now the PDFs are saved with all regional fonts.